### PR TITLE
feat: on io::Error disconnect, send incoming disconnect message.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,9 @@ bytes = "0.5"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 thiserror = "1.0"
 tokio = { version = "0.2.13", features = ["full"] }
+#tokio = { path="../tokio/tokio", features = ["full"] }
 tokio-util = { version = "0.2", features = ["codec"] }
+#tokio-util = { path="../tokio/tokio-util", features = ["codec"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-futures = "0.2"
 tinyvec = { version = "0.3", features = ["alloc"] }
@@ -28,4 +30,7 @@ either = "1.5.3"
 futures = { version = "0.3", default-features = false, features = ["alloc","std"] }
 matches = "0.1"
 tokio = { version = "0.2.13", features = ["full", "test-util"] }
+#tokio = { path="../tokio/tokio", features = ["full", "test-util"] }
+tokio-test = "0.2.0"
+#tokio-test = { path="../tokio/tokio-test" }
 tracing-subscriber = "0.2"

--- a/src/halt.rs
+++ b/src/halt.rs
@@ -132,7 +132,7 @@ where
                     let _ = self.shutdown();
                     Poll::Ready(Some(IncomingPacket::StreamDisconnected(
                         stream_id,
-                        DisconnectReason::Graceful,
+                        DisconnectReason::Linkdead,
                     )))
                 }
             }

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -24,7 +24,8 @@ impl<V> IncomingMessage<V> {
 /// The reason why a stream was removed from a channel.
 pub enum DisconnectReason {
     /// Stream client disconnected.
-    Graceful,
+    /// Could be a normal disconnect, or caused by an IO Error.
+    Linkdead,
 
     /// Stream was moved into the given channel.
     ChannelChange(ChannelId),


### PR DESCRIPTION
This happens when a ConnectionReset error occurs.

Closes #32